### PR TITLE
[Feature] New Implementation of Alternative Camera Mode - Offset Camera

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,7 @@ resources/text_dumper/bin
 .cache/
 .vscode/
 /backend
+
+# agent files
+.sisyphus/
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 | 配置项     | 类型  | 默认值  | 说明               |
 | ---------- | ----- | ------- | ------------------ |
 | enable     | Bool  | `false` | 启用自由视角       |
+| enableCameraOffset | Bool  | `false` | 启用镜头偏移模式（与 enable 互斥） |
 | moveStep   | Float | `50`    | 摄像机移动速度     |
 | mouseSpeed | Float | `35`    | 鼠标移动视角灵敏度 |
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
 | 配置项     | 类型  | 默认值  | 说明               |
 | ---------- | ----- | ------- | ------------------ |
 | enable     | Bool  | `false` | 启用自由视角       |
-| enableCameraOffset | Bool  | `false` | 启用镜头偏移模式（与 enable 互斥） |
+| enableOffsetCamera | Bool  | `false` | 启用镜头偏移模式（与 enable 互斥） |
 | moveStep   | Float | `50`    | 摄像机移动速度     |
 | mouseSpeed | Float | `35`    | 鼠标移动视角灵敏度 |
 
@@ -94,12 +94,14 @@
 
 > 下述为默认按键，具体按键可以通过配置文件进行自定义
 
-- 移动: `W`, `S`, `A`, `D`
+- 移动: `I`, `K`, `J`, `L`
 - 上移: `Space` （插件v1.3.6开始分发的配置文件中重载为 `Alt`），下移: `Ctrl`
-- 摄像头复位: `R`
+- 复制当前游戏镜头参数到自由视角: `R`
 
 - 视角转动: 
-  - 键盘: `↑`, `↓`, `←`, `→`
+  - 键盘: `Numpad 8`, `Numpad 2`, `Numpad 4`, `Numpad 6`
+  > **注意：Numpad 方向键需开启 NumLock 才能使用**
+  - 滚转: `Numpad 7` (左滚), `Numpad 9` (右滚)
   - 鼠标: 
     - 按 ` 键（数字键最左边，TAB 键上方）切换
     - 或者**按住**鼠标右键
@@ -115,21 +117,24 @@
 
 | 配置项                       | 默认值                     |
 | --------------------------- | ------------------------- |
-| key_w_camera_forward        | `W`                       |
-| key_s_camera_back           | `S`                       |
-| key_a_camera_left           | `A`                       |
-| key_d_camera_right          | `D`                       |
+| key_w_camera_forward        | `I`                       |
+| key_s_camera_back           | `K`                       |
+| key_a_camera_left           | `J`                       |
+| key_d_camera_right          | `L`                       |
 | key_ctrl_camera_down        | `17` (ctrl)               |
 | key_space_camera_up         | `18` (alt)                |
-| key_up_cameralookat_up      | `38` (↑)                  |
-| key_down_cameralookat_down  | `40` (↓)                  |
-| key_left_cameralookat_left  | `37` (←)                  |
-| key_right_cameralookat_right| `39` (→)                  |
+| key_up_cameralookat_up      | `104` (Numpad 8)          |
+| key_down_cameralookat_down  | `98` (Numpad 2)           |
+| key_left_cameralookat_left  | `100` (Numpad 4)          |
+| key_right_cameralookat_right| `102` (Numpad 6)          |
+| key_numpad7_camera_roll_left | `103` (Numpad 7)          |
+| key_numpad9_camera_roll_right| `105` (Numpad 9)          |
 | key_q_camera_fov_increase   | `Q`                       |
 | key_e_camera_fov_decrease   | `E`                       |
 | key_r_camera_reset          | `R`                       |
 | key_192_camera_mouseMove    | `192` (`` ` ``, backtick) |
 
+> **注意：使用小键盘按键时，需确保 NumLock 处于开启状态；按键设置可在 scsp-config.json 中自定义**
 
 JSON值说明：对于按键设置接受以下两种类型的值：
 - `char[1]` 单字节字符串，即用双引号包绕的单个字母或数字，表示相应的按键，如 `"W"` 表示W键

--- a/readme_EN.md
+++ b/readme_EN.md
@@ -67,7 +67,7 @@ iM@S SCSP localify plugin.
 | Configuration Item | Type   | Default Value | Description         |
 | ------------------ | ------ | ------------- | --------------------|
 | enable             | Bool   | `false`       | Enable free camera  |
-| enableCameraOffset | Bool   | `false`       | Enable camera offset mode (mutually exclusive with `enable`) |
+| enableOffsetCamera | Bool   | `false`       | Enable camera offset mode (mutually exclusive with `enable`) |
 | moveStep           | Float  | `50`          | Camera movement speed |
 | mouseSpeed         | Float  | `35`          | Mouse sensitivity for camera movement |
 
@@ -95,12 +95,14 @@ iM@S SCSP localify plugin.
 
 ## Free Camera Operation Method
 
-- Movement: `W`, `S`, `A`, `D`
+- Movement: `I`, `K`, `J`, `L`
 - Ascend: `Space` (overwritten as `Alt` in config files distributed after plugin v1.3.6), Descend: `Ctrl`
-- Reset camera: `R`
+- Copy current game camera to free camera: `R`
 
 - Camera Rotation: 
-  - Keyboard: `↑`, `↓`, `←`, `→`
+  - Keyboard: `Numpad 8`, `Numpad 2`, `Numpad 4`, `Numpad 6`
+  > **Note: Numpad keys require NumLock to be ON**
+  - Roll: `Numpad 7` (roll left), `Numpad 9` (roll right)
   - Mouse: 
     - Press the ` key (located to the left of the number keys, above the TAB key)
     - Or **hold down** the right mouse button
@@ -115,21 +117,24 @@ iM@S SCSP localify plugin.
 
 | Configuration Item          | Default Value             |
 | --------------------------- | ------------------------- |
-| key_w_camera_forward        | `W`                       |
-| key_s_camera_back           | `S`                       |
-| key_a_camera_left           | `A`                       |
-| key_d_camera_right          | `D`                       |
+| key_w_camera_forward        | `I`                       |
+| key_s_camera_back           | `K`                       |
+| key_a_camera_left           | `J`                       |
+| key_d_camera_right          | `L`                       |
 | key_ctrl_camera_down        | `17` (ctrl)               |
 | key_space_camera_up         | `18` (alt)                |
-| key_up_cameralookat_up      | `38` (↑)                  |
-| key_down_cameralookat_down  | `40` (↓)                  |
-| key_left_cameralookat_left  | `37` (←)                  |
-| key_right_cameralookat_right| `39` (→)                  |
+| key_up_cameralookat_up      | `104` (Numpad 8)          |
+| key_down_cameralookat_down  | `98` (Numpad 2)           |
+| key_left_cameralookat_left  | `100` (Numpad 4)          |
+| key_right_cameralookat_right| `102` (Numpad 6)          |
+| key_numpad7_camera_roll_left | `103` (Numpad 7)          |
+| key_numpad9_camera_roll_right| `105` (Numpad 9)          |
 | key_q_camera_fov_increase   | `Q`                       |
 | key_e_camera_fov_decrease   | `E`                       |
 | key_r_camera_reset          | `R`                       |
 | key_192_camera_mouseMove    | `192` (`` ` ``, backtick) |
 
+> **Note: Numpad keys require NumLock to be enabled. Key bindings can be customized in scsp-config.json**
 
 About JSON value: For key bindings, two types of values are acceptable:
 - `char[1]` single character string, wrapped by double quotes, to express the letter key, like `"W"` for key W

--- a/readme_EN.md
+++ b/readme_EN.md
@@ -67,6 +67,7 @@ iM@S SCSP localify plugin.
 | Configuration Item | Type   | Default Value | Description         |
 | ------------------ | ------ | ------------- | --------------------|
 | enable             | Bool   | `false`       | Enable free camera  |
+| enableCameraOffset | Bool   | `false`       | Enable camera offset mode (mutually exclusive with `enable`) |
 | moveStep           | Float  | `50`          | Camera movement speed |
 | mouseSpeed         | Float  | `35`          | Mouse sensitivity for camera movement |
 

--- a/resources/scsp-config.json
+++ b/resources/scsp-config.json
@@ -23,5 +23,15 @@
     "h": 720,
     "isFull": false
   },
-  "key_space_camera_up": 18
+  "key_space_camera_up": 18,
+  "key_w_camera_forward": "I",
+  "key_s_camera_back": "K",
+  "key_a_camera_left": "J",
+  "key_d_camera_right": "L",
+  "key_up_cameralookat_up": 104,
+  "key_down_cameralookat_down": 98,
+  "key_left_cameralookat_left": 100,
+  "key_right_cameralookat_right": 102,
+  "key_numpad7_camera_roll_left": 103,
+  "key_numpad9_camera_roll_right": 105
 }

--- a/resources/scsp-config.json
+++ b/resources/scsp-config.json
@@ -13,6 +13,7 @@
   "blockOutOfFocus": true,
   "baseFreeCamera": {
     "enable": false,
+    "enableCameraOffset": false,
     "moveStep": 50,
     "mouseSpeed": 35
   },

--- a/resources/scsp-config.json
+++ b/resources/scsp-config.json
@@ -13,7 +13,7 @@
   "blockOutOfFocus": true,
   "baseFreeCamera": {
     "enable": false,
-    "enableCameraOffset": false,
+    "enableOffsetCamera": false,
     "moveStep": 50,
     "mouseSpeed": 35
   },

--- a/src/camera/baseCamera.cpp
+++ b/src/camera/baseCamera.cpp
@@ -109,12 +109,12 @@ namespace BaseCamera {
 		//  roll, pitch, yaw
 		Vector3 Quaternion::ToEuler() {
 			Vector3 euler(0, 0, 0);
-			// ���� roll (x-axis rotation)
+			// 计算 roll (x-axis rotation)
 			double sinr = 2.0 * (w * x + y * z);
 			double cosr = 1.0 - 2.0 * (x * x + y * y);
 			euler.x = atan2(sinr, cosr);
 
-			// ���� pitch (y-axis rotation)
+			// 计算 pitch (y-axis rotation)
 			double sinp = 2.0 * (w * y - z * x);
 			if (fabs(sinp) >= 1) {
 				euler.y = copysign(M_PI / 2, sinp); // use 90 degrees if out of range
@@ -123,7 +123,7 @@ namespace BaseCamera {
 				euler.y = asin(sinp);
 			}
 
-			// ���� yaw (z-axis rotation)
+			// 计算 yaw (z-axis rotation)
 			double siny = 2.0 * (w * z + x * y);
 			double cosy = 1.0 - 2.0 * (y * y + z * z);
 			euler.z = atan2(siny, cosy);
@@ -151,7 +151,7 @@ namespace BaseCamera {
 			return q1.w * q2.w + q1.x * q2.x + q1.y * q2.y + q1.z * q2.z;
 		}
 
-		// ����н�
+		// 计算夹角
 		float Quaternion::Acos(const float x) {
 			if (x < -1.0f) {
 				return M_PI;
@@ -164,7 +164,7 @@ namespace BaseCamera {
 			}
 		}
 
-		// Slerp����
+		// Slerp方法
 		Quaternion Quaternion::Slerp(const Quaternion& q1, const Quaternion& q2, const float t) {
 			Quaternion q3(0, 0, 0, 0);
 			float dot = Quaternion::Dot(q1, q2);
@@ -347,12 +347,12 @@ namespace BaseCamera {
 		return lookAt;
 	}
 
-	void Camera::set_lon_move(float vertanglePlus, LonMoveHState moveState) {  // ǰ���ƶ�
+	void Camera::set_lon_move(float vertanglePlus, LonMoveHState moveState) {  // 前后移动
 		auto radian = (verticalAngle + vertanglePlus) * M_PI / 180;
 		auto radianH = (double)horizontalAngle * M_PI / 180;
 
-		auto f_step = cos(radian) * moveStep * cos(radianH) / smoothLevel;  // ����
-		auto l_step = sin(radian) * moveStep * cos(radianH) / smoothLevel;  // ����
+		auto f_step = cos(radian) * moveStep * cos(radianH) / smoothLevel;  // ↑↓
+		auto l_step = sin(radian) * moveStep * cos(radianH) / smoothLevel;  // ←→
 		// auto h_step = tan(radianH) * sqrt(pow(f_step, 2) + pow(l_step, 2));
 		auto h_step = sin(radianH) * moveStep / smoothLevel;
 
@@ -374,9 +374,9 @@ namespace BaseCamera {
 		}
 	}
 
-	void Camera::updateVertLook() {  // ��+
+	void Camera::updateVertLook() {  // 上+
 		auto radian = verticalAngle * M_PI / 180;
-		auto radian2 = ((double)horizontalAngle - 90) * M_PI / 180;  // ��
+		auto radian2 = ((double)horizontalAngle - 90) * M_PI / 180;  // 日
 
 		auto stepX1 = look_radius * sin(radian2) * cos(radian) / smoothLevel;
 		auto stepX2 = look_radius * sin(radian2) * sin(radian) / smoothLevel;
@@ -390,7 +390,7 @@ namespace BaseCamera {
 		}
 	}
 
-	void Camera::setHoriLook(float vertangle) {  // ��+
+	void Camera::setHoriLook(float vertangle) {  // 左+
 		auto radian = vertangle * M_PI / 180;
 		auto radian2 = horizontalAngle * M_PI / 180;
 

--- a/src/camera/baseCamera.cpp
+++ b/src/camera/baseCamera.cpp
@@ -109,12 +109,12 @@ namespace BaseCamera {
 		//  roll, pitch, yaw
 		Vector3 Quaternion::ToEuler() {
 			Vector3 euler(0, 0, 0);
-			// ¼ÆËã roll (x-axis rotation)
+			// ï¿½ï¿½ï¿½ï¿½ roll (x-axis rotation)
 			double sinr = 2.0 * (w * x + y * z);
 			double cosr = 1.0 - 2.0 * (x * x + y * y);
 			euler.x = atan2(sinr, cosr);
 
-			// ¼ÆËã pitch (y-axis rotation)
+			// ï¿½ï¿½ï¿½ï¿½ pitch (y-axis rotation)
 			double sinp = 2.0 * (w * y - z * x);
 			if (fabs(sinp) >= 1) {
 				euler.y = copysign(M_PI / 2, sinp); // use 90 degrees if out of range
@@ -123,7 +123,7 @@ namespace BaseCamera {
 				euler.y = asin(sinp);
 			}
 
-			// ¼ÆËã yaw (z-axis rotation)
+			// ï¿½ï¿½ï¿½ï¿½ yaw (z-axis rotation)
 			double siny = 2.0 * (w * z + x * y);
 			double cosy = 1.0 - 2.0 * (y * y + z * z);
 			euler.z = atan2(siny, cosy);
@@ -151,7 +151,7 @@ namespace BaseCamera {
 			return q1.w * q2.w + q1.x * q2.x + q1.y * q2.y + q1.z * q2.z;
 		}
 
-		// ¼ÆËã¼Ð½Ç
+		// ï¿½ï¿½ï¿½ï¿½Ð½ï¿½
 		float Quaternion::Acos(const float x) {
 			if (x < -1.0f) {
 				return M_PI;
@@ -164,7 +164,7 @@ namespace BaseCamera {
 			}
 		}
 
-		// Slerp·½·¨
+		// Slerpï¿½ï¿½ï¿½ï¿½
 		Quaternion Quaternion::Slerp(const Quaternion& q1, const Quaternion& q2, const float t) {
 			Quaternion q3(0, 0, 0, 0);
 			float dot = Quaternion::Dot(q1, q2);
@@ -289,8 +289,8 @@ namespace BaseCamera {
 
 
 	float moveStep = 0.05;
-	float look_radius = 5;  // ×ªÏò°ë¾¶
-	float moveAngel = 1.5;  // ×ªÏò½Ç¶È
+	float look_radius = 5;  // ×ªï¿½ï¿½ë¾¶
+	float moveAngel = 1.5;  // ×ªï¿½ï¿½Ç¶ï¿½
 
 	int smoothLevel = 1;
 	unsigned long sleepTime = 0;
@@ -335,6 +335,8 @@ namespace BaseCamera {
 		fov = 60;
 		verticalAngle = 0;
 		horizontalAngle = 0;
+		rot = {1, 0, 0, 0};
+		setRotFromLookAt();
 	}
 
 	CameraCalc::Vector3 Camera::getPos() {
@@ -345,12 +347,12 @@ namespace BaseCamera {
 		return lookAt;
 	}
 
-	void Camera::set_lon_move(float vertanglePlus, LonMoveHState moveState) {  // Ç°ºóÒÆ¶¯
+	void Camera::set_lon_move(float vertanglePlus, LonMoveHState moveState) {  // Ç°ï¿½ï¿½ï¿½Æ¶ï¿½
 		auto radian = (verticalAngle + vertanglePlus) * M_PI / 180;
 		auto radianH = (double)horizontalAngle * M_PI / 180;
 
-		auto f_step = cos(radian) * moveStep * cos(radianH) / smoothLevel;  // ¡ü¡ý
-		auto l_step = sin(radian) * moveStep * cos(radianH) / smoothLevel;  // ¡û¡ú
+		auto f_step = cos(radian) * moveStep * cos(radianH) / smoothLevel;  // ï¿½ï¿½ï¿½ï¿½
+		auto l_step = sin(radian) * moveStep * cos(radianH) / smoothLevel;  // ï¿½ï¿½ï¿½ï¿½
 		// auto h_step = tan(radianH) * sqrt(pow(f_step, 2) + pow(l_step, 2));
 		auto h_step = sin(radianH) * moveStep / smoothLevel;
 
@@ -372,9 +374,9 @@ namespace BaseCamera {
 		}
 	}
 
-	void Camera::updateVertLook() {  // ÉÏ+
+	void Camera::updateVertLook() {  // ï¿½ï¿½+
 		auto radian = verticalAngle * M_PI / 180;
-		auto radian2 = ((double)horizontalAngle - 90) * M_PI / 180;  // ÈÕ
+		auto radian2 = ((double)horizontalAngle - 90) * M_PI / 180;  // ï¿½ï¿½
 
 		auto stepX1 = look_radius * sin(radian2) * cos(radian) / smoothLevel;
 		auto stepX2 = look_radius * sin(radian2) * sin(radian) / smoothLevel;
@@ -388,7 +390,7 @@ namespace BaseCamera {
 		}
 	}
 
-	void Camera::setHoriLook(float vertangle) {  // ×ó+
+	void Camera::setHoriLook(float vertangle) {  // ï¿½ï¿½+
 		auto radian = vertangle * M_PI / 180;
 		auto radian2 = horizontalAngle * M_PI / 180;
 
@@ -415,6 +417,59 @@ namespace BaseCamera {
 		lookatPosition->x = retPos.x;
 		lookatPosition->y = retPos.y;
 		lookatPosition->z = retPos.z;
+	}
+
+	void Camera::setRotFromLookAt() {
+		CameraCalc::Vector3 dir = lookAt - pos;
+		dir = dir.normalized();
+		CameraCalc::Vector3 up(0, 1, 0);
+		auto q = CameraCalc::LookRotation(dir, up);
+		// LookRotation returns Quaternion(qx, qy, qz, qw) via ctor(w,x,y,z),
+		// so q.w=qx_actual, q.x=qy_actual, q.y=qz_actual, q.z=qw_actual.
+		// Quaternion_t expects {w_actual, x_actual, y_actual, z_actual} = {q.z, q.w, q.x, q.y}.
+		rot = Quaternion_t{ q.z, q.w, q.x, q.y };
+	}
+
+	void Camera::setLookAtFromRot() {
+		Vector3_t vPos{ pos.x, pos.y, pos.z };
+		const auto vLookAt = CameraCalc::GetFrontPos(vPos, rot, look_radius);
+		lookAt.x = vLookAt.x;
+		lookAt.y = vLookAt.y;
+		lookAt.z = vLookAt.z;
+	}
+
+	void Camera::setRotEulerDeg(float pitch, float yaw, float roll) {
+		CameraCalc::Vector3 euler(
+			pitch * (float)M_PI / 180.0f,
+			yaw   * (float)M_PI / 180.0f,
+			roll  * (float)M_PI / 180.0f
+		);
+		auto q = CameraCalc::Quaternion::FromEuler(euler);
+		rot = (Quaternion_t)q;
+	}
+
+	void Camera::getRotEulerDeg(float* pitch, float* yaw, float* roll) {
+		CameraCalc::Quaternion q(rot.w, rot.x, rot.y, rot.z);
+		auto euler = q.ToEuler();
+		*pitch = euler.x * 180.0f / (float)M_PI;
+		*yaw   = euler.y * 180.0f / (float)M_PI;
+		*roll  = euler.z * 180.0f / (float)M_PI;
+	}
+
+	void Camera::rotateLocal(float angleDeg, float axisX, float axisY, float axisZ) {
+		CameraCalc::Quaternion q(rot.w, rot.x, rot.y, rot.z);
+		if (q.w == 0 && q.x == 0 && q.y == 0 && q.z == 0) q = CameraCalc::Quaternion(1, 0, 0, 0);
+		auto result = CameraCalc::RotateQuaternion(q, angleDeg, CameraCalc::Vector3(axisX, axisY, axisZ));
+		rot = (Quaternion_t)result;
+		setLookAtFromRot();
+	}
+
+	void Camera::rotateWorldY(float angleDeg) {
+		CameraCalc::Quaternion q(rot.w, rot.x, rot.y, rot.z);
+		if (q.w == 0 && q.x == 0 && q.y == 0 && q.z == 0) q = CameraCalc::Quaternion(1, 0, 0, 0);
+		auto result = CameraCalc::RotateQuaternion(q, angleDeg, CameraCalc::Vector3(0, 1, 0));
+		rot = (Quaternion_t)result;
+		setLookAtFromRot();
 	}
 
 }

--- a/src/camera/baseCamera.hpp
+++ b/src/camera/baseCamera.hpp
@@ -45,18 +45,20 @@ namespace BaseCamera {
 			static Quaternion FromEuler(Vector3 euler);
 			static float Dot(const Quaternion& q1, const Quaternion& q2);
 
-			// ¼ÆËã¼Ð½Ç
+			// ï¿½ï¿½ï¿½ï¿½Ð½ï¿½
 			static float Acos(const float x);
 
-			// Slerp·½·¨
+			// Slerpï¿½ï¿½ï¿½ï¿½
 			static Quaternion Slerp(const Quaternion& q1, const Quaternion& q2, const float t);
 		};
 
+		Quaternion RotateQuaternion(const Quaternion& q, float angle_degrees, const Vector3& axis);
+		Vector3 RotateVector(const Quaternion& q, const Vector3& v);
 	}
 
 	extern float moveStep;
-	extern float look_radius;  // ×ªÏò°ë¾¶
-	extern float moveAngel;  // ×ªÏò½Ç¶È
+	extern float look_radius;  // ×ªï¿½ï¿½ë¾¶
+	extern float moveAngel;  // ×ªï¿½ï¿½Ç¶ï¿½
 
 	extern int smoothLevel;
 	extern unsigned long sleepTime;
@@ -86,8 +88,17 @@ namespace BaseCamera {
 		CameraCalc::Vector3 lookAt{0.5, 1.1, -3.7};
 		float fov = 60;
 
-		float horizontalAngle = 0;  // Ë®Æ½·½Ïò½Ç¶È
-		float verticalAngle = 0;  // ´¹Ö±·½Ïò½Ç¶È
+		float horizontalAngle = 0;  // Ë®Æ½ï¿½ï¿½ï¿½ï¿½Ç¶ï¿½
+		float verticalAngle = 0;  // ï¿½ï¿½Ö±ï¿½ï¿½ï¿½ï¿½Ç¶ï¿½
+
+		Quaternion_t rot{1, 0, 0, 0};  // identity quaternion: w=1, x=0, y=0, z=0
+
+		void setRotFromLookAt();
+		void setLookAtFromRot();
+		void setRotEulerDeg(float pitch, float yaw, float roll);
+		void getRotEulerDeg(float* pitch, float* yaw, float* roll);
+		void rotateLocal(float angleDeg, float axisX, float axisY, float axisZ);
+		void rotateWorldY(float angleDeg);
 
 	};
 

--- a/src/camera/baseCamera.hpp
+++ b/src/camera/baseCamera.hpp
@@ -45,10 +45,10 @@ namespace BaseCamera {
 			static Quaternion FromEuler(Vector3 euler);
 			static float Dot(const Quaternion& q1, const Quaternion& q2);
 
-			// ����н�
+			// 计算夹角
 			static float Acos(const float x);
 
-			// Slerp����
+			// Slerp方法
 			static Quaternion Slerp(const Quaternion& q1, const Quaternion& q2, const float t);
 		};
 
@@ -57,8 +57,8 @@ namespace BaseCamera {
 	}
 
 	extern float moveStep;
-	extern float look_radius;  // ת��뾶
-	extern float moveAngel;  // ת��Ƕ�
+	extern float look_radius;  // 转向半径
+	extern float moveAngel;  // 转向角度
 
 	extern int smoothLevel;
 	extern unsigned long sleepTime;
@@ -88,8 +88,8 @@ namespace BaseCamera {
 		CameraCalc::Vector3 lookAt{0.5, 1.1, -3.7};
 		float fov = 60;
 
-		float horizontalAngle = 0;  // ˮƽ����Ƕ�
-		float verticalAngle = 0;  // ��ֱ����Ƕ�
+		float horizontalAngle = 0;  // 水平方向角度
+		float verticalAngle = 0;  // 垂直方向角度
 
 		Quaternion_t rot{1, 0, 0, 0};  // identity quaternion: w=1, x=0, y=0, z=0
 

--- a/src/camera/camera.cpp
+++ b/src/camera/camera.cpp
@@ -1,6 +1,7 @@
 #include <stdinclude.hpp>
 #include "camera/baseCamera.hpp"
 #include <mhotkey.hpp>
+#include "scgui/scGUIData.hpp"
 
 
 namespace SCCamera {
@@ -10,23 +11,69 @@ namespace SCCamera {
 
 	bool rMousePressFlg = false;
 
-	void reset_camera() {
-		baseCamera.reset();
+	static BaseCamera::CameraCalc::Quaternion safeRot() {
+		auto& r = baseCamera.rot;
+		if (r.w == 0 && r.x == 0 && r.y == 0 && r.z == 0)
+			return BaseCamera::CameraCalc::Quaternion(1, 0, 0, 0);
+		return BaseCamera::CameraCalc::Quaternion(r.w, r.x, r.y, r.z);
 	}
 
-	void camera_forward() {  // ÏòÇ°
-		baseCamera.set_lon_move(0, LonMoveHState::LonMoveForward);
+	void reset_camera() {
+		baseCamera.fov = SCGUIData::sysCamFov;
+		baseCamera.pos.x = SCGUIData::sysCamPos.x;
+		baseCamera.pos.y = SCGUIData::sysCamPos.y;
+		baseCamera.pos.z = SCGUIData::sysCamPos.z;
+		baseCamera.rot = SCGUIData::sysCamRot;
+		baseCamera.setLookAtFromRot();
+		baseCamera.horizontalAngle = 0;
+		baseCamera.verticalAngle = 0;
 	}
-	void camera_back() {  // ºóÍË
-		baseCamera.set_lon_move(180, LonMoveHState::LonMoveBack);
+
+	void camera_forward() {  // ï¿½ï¿½Ç°
+		auto q = safeRot();
+		BaseCamera::CameraCalc::Vector3 fwd = BaseCamera::CameraCalc::RotateVector(q, BaseCamera::CameraCalc::Vector3(0, 0, 1));
+		float step = BaseCamera::moveStep;
+		baseCamera.pos.x += fwd.x * step;
+		baseCamera.pos.y += fwd.y * step;
+		baseCamera.pos.z += fwd.z * step;
+		baseCamera.lookAt.x += fwd.x * step;
+		baseCamera.lookAt.y += fwd.y * step;
+		baseCamera.lookAt.z += fwd.z * step;
 	}
-	void camera_left() {  // Ïò×ó
-		baseCamera.set_lon_move(90);
+	void camera_back() {  // ï¿½ï¿½ï¿½ï¿½
+		auto q = safeRot();
+		BaseCamera::CameraCalc::Vector3 fwd = BaseCamera::CameraCalc::RotateVector(q, BaseCamera::CameraCalc::Vector3(0, 0, 1));
+		float step = BaseCamera::moveStep;
+		baseCamera.pos.x -= fwd.x * step;
+		baseCamera.pos.y -= fwd.y * step;
+		baseCamera.pos.z -= fwd.z * step;
+		baseCamera.lookAt.x -= fwd.x * step;
+		baseCamera.lookAt.y -= fwd.y * step;
+		baseCamera.lookAt.z -= fwd.z * step;
 	}
-	void camera_right() {  // ÏòÓÒ
-		baseCamera.set_lon_move(-90);
+	void camera_left() {  // ï¿½ï¿½ï¿½ï¿½
+		auto q = safeRot();
+		BaseCamera::CameraCalc::Vector3 right = BaseCamera::CameraCalc::RotateVector(q, BaseCamera::CameraCalc::Vector3(1, 0, 0));
+		float step = BaseCamera::moveStep;
+		baseCamera.pos.x += right.x * step;
+		baseCamera.pos.y += right.y * step;
+		baseCamera.pos.z += right.z * step;
+		baseCamera.lookAt.x += right.x * step;
+		baseCamera.lookAt.y += right.y * step;
+		baseCamera.lookAt.z += right.z * step;
 	}
-	void camera_down() {  // ÏòÏÂ
+	void camera_right() {  // ï¿½ï¿½ï¿½ï¿½
+		auto q = safeRot();
+		BaseCamera::CameraCalc::Vector3 right = BaseCamera::CameraCalc::RotateVector(q, BaseCamera::CameraCalc::Vector3(1, 0, 0));
+		float step = BaseCamera::moveStep;
+		baseCamera.pos.x -= right.x * step;
+		baseCamera.pos.y -= right.y * step;
+		baseCamera.pos.z -= right.z * step;
+		baseCamera.lookAt.x -= right.x * step;
+		baseCamera.lookAt.y -= right.y * step;
+		baseCamera.lookAt.z -= right.z * step;
+	}
+	void camera_down() {  // ï¿½ï¿½ï¿½ï¿½
 		float preStep = BaseCamera::moveStep / BaseCamera::smoothLevel;
 
 		for (int i = 0; i < BaseCamera::smoothLevel; i++) {
@@ -35,7 +82,7 @@ namespace SCCamera {
 			Sleep(BaseCamera::sleepTime);
 		}
 	}
-	void camera_up() {  // ÏòÉÏ
+	void camera_up() {  // ï¿½ï¿½ï¿½ï¿½
 		float preStep = BaseCamera::moveStep / BaseCamera::smoothLevel;
 
 		for (int i = 0; i < BaseCamera::smoothLevel; i++) {
@@ -45,24 +92,22 @@ namespace SCCamera {
 		}
 	}
 	void cameraLookat_up(float mAngel, bool mouse = false) {
-		baseCamera.horizontalAngle += mAngel;
-		if (baseCamera.horizontalAngle >= 90) baseCamera.horizontalAngle = 89.99;
-		baseCamera.updateVertLook();
+		baseCamera.rotateLocal(-mAngel, 0, 0, 1);
 	}
 	void cameraLookat_down(float mAngel, bool mouse = false) {
-		baseCamera.horizontalAngle -= mAngel;
-		if (baseCamera.horizontalAngle <= -90) baseCamera.horizontalAngle = -89.99;
-		baseCamera.updateVertLook();
+		baseCamera.rotateLocal(mAngel, 0, 0, 1);
 	}
 	void cameraLookat_left(float mAngel) {
-		baseCamera.verticalAngle += mAngel;
-		if (baseCamera.verticalAngle >= 360) baseCamera.verticalAngle = -360;
-		baseCamera.setHoriLook(baseCamera.verticalAngle);
+		baseCamera.rotateWorldY(mAngel);
 	}
 	void cameraLookat_right(float mAngel) {
-		baseCamera.verticalAngle -= mAngel;
-		if (baseCamera.verticalAngle <= -360) baseCamera.verticalAngle = 360;
-		baseCamera.setHoriLook(baseCamera.verticalAngle);
+		baseCamera.rotateWorldY(-mAngel);
+	}
+	void cameraRoll_left(float mAngel) {
+		baseCamera.rotateLocal(mAngel, 1, 0, 0);
+	}
+	void cameraRoll_right(float mAngel) {
+		baseCamera.rotateLocal(-mAngel, 1, 0, 0);
 	}
 	void changeCameraFOV(float value) {
 		baseCamera.fov += value;
@@ -129,6 +174,8 @@ namespace SCCamera {
 		bool k = false;
 		bool j = false;
 		bool l = false;
+		bool numpad7 = false;
+		bool numpad9 = false;
 		bool threadRunning = false;
 
 		void resetAll() {
@@ -169,6 +216,8 @@ namespace SCCamera {
 				if (cameraMoveState.right) cameraLookat_right(moveAngel);
 				if (cameraMoveState.q) changeCameraFOV(0.5f);
 				if (cameraMoveState.e) changeCameraFOV(-0.5f);
+				if (cameraMoveState.numpad7) cameraRoll_left(moveAngel);
+				if (cameraMoveState.numpad9) cameraRoll_right(moveAngel);
 				// if (cameraMoveState.i) changeLiveFollowCameraOffsetY(moveStep / 3);
 				// if (cameraMoveState.k) changeLiveFollowCameraOffsetY(-moveStep / 3);
 				// if (cameraMoveState.j) changeLiveFollowCameraOffsetX(moveStep * 10);
@@ -211,6 +260,10 @@ namespace SCCamera {
 				cameraMoveState.q = isKeyDown; break;
 			case KEY_E:
 				cameraMoveState.e = isKeyDown; break;
+			case KEY_NUMPAD7:
+				cameraMoveState.numpad7 = isKeyDown; break;
+			case KEY_NUMPAD9:
+				cameraMoveState.numpad9 = isKeyDown; break;
 				//case 'I':
 				//	cameraMoveState.i = isKeyDown; break;
 				//case 'K':

--- a/src/camera/camera.cpp
+++ b/src/camera/camera.cpp
@@ -29,7 +29,7 @@ namespace SCCamera {
 		baseCamera.verticalAngle = 0;
 	}
 
-	void camera_forward() {  // ��ǰ
+	void camera_forward() {  // 向前
 		auto q = safeRot();
 		BaseCamera::CameraCalc::Vector3 fwd = BaseCamera::CameraCalc::RotateVector(q, BaseCamera::CameraCalc::Vector3(0, 0, 1));
 		float step = BaseCamera::moveStep;
@@ -40,7 +40,7 @@ namespace SCCamera {
 		baseCamera.lookAt.y += fwd.y * step;
 		baseCamera.lookAt.z += fwd.z * step;
 	}
-	void camera_back() {  // ����
+	void camera_back() {  // 后退
 		auto q = safeRot();
 		BaseCamera::CameraCalc::Vector3 fwd = BaseCamera::CameraCalc::RotateVector(q, BaseCamera::CameraCalc::Vector3(0, 0, 1));
 		float step = BaseCamera::moveStep;
@@ -51,7 +51,7 @@ namespace SCCamera {
 		baseCamera.lookAt.y -= fwd.y * step;
 		baseCamera.lookAt.z -= fwd.z * step;
 	}
-	void camera_left() {  // ����
+	void camera_left() {  // 向左
 		auto q = safeRot();
 		BaseCamera::CameraCalc::Vector3 right = BaseCamera::CameraCalc::RotateVector(q, BaseCamera::CameraCalc::Vector3(1, 0, 0));
 		float step = BaseCamera::moveStep;
@@ -62,7 +62,7 @@ namespace SCCamera {
 		baseCamera.lookAt.y += right.y * step;
 		baseCamera.lookAt.z += right.z * step;
 	}
-	void camera_right() {  // ����
+	void camera_right() {  // 向右
 		auto q = safeRot();
 		BaseCamera::CameraCalc::Vector3 right = BaseCamera::CameraCalc::RotateVector(q, BaseCamera::CameraCalc::Vector3(1, 0, 0));
 		float step = BaseCamera::moveStep;
@@ -73,7 +73,7 @@ namespace SCCamera {
 		baseCamera.lookAt.y -= right.y * step;
 		baseCamera.lookAt.z -= right.z * step;
 	}
-	void camera_down() {  // ����
+	void camera_down() {  // 向下
 		float preStep = BaseCamera::moveStep / BaseCamera::smoothLevel;
 
 		for (int i = 0; i < BaseCamera::smoothLevel; i++) {
@@ -82,7 +82,7 @@ namespace SCCamera {
 			Sleep(BaseCamera::sleepTime);
 		}
 	}
-	void camera_up() {  // ����
+	void camera_up() {  // 向上
 		float preStep = BaseCamera::moveStep / BaseCamera::smoothLevel;
 
 		for (int i = 0; i < BaseCamera::smoothLevel; i++) {

--- a/src/hook.cpp
+++ b/src/hook.cpp
@@ -2607,14 +2607,49 @@ namespace
 	}
 	HOOK_ORIG_TYPE Unity_get_fieldOfView_orig;
 	float Unity_get_fieldOfView_hook(void* _this) {
+		static void* lastCameraForOffset = nullptr;
+		static bool offsetFovValid = false;
+		static float lastRawFov = 0.0f;
+		static float lastAppliedFov = 0.0f;
+
 		const auto origFov = HOOK_CAST_CALL(float, Unity_get_fieldOfView)(_this);
 		if (_this == baseCamera) {
+			if (lastCameraForOffset != _this) {
+				lastCameraForOffset = _this;
+				offsetFovValid = false;
+			}
+
 			if (guiStarting) {
-				SCGUIData::sysCamFov = origFov;
+				float baseFov = origFov;
+				if (!g_enable_free_camera && g_enable_camera_offset && offsetFovValid) {
+					auto diff = origFov - lastAppliedFov;
+					if (diff < 0.0f) diff = -diff;
+					if (diff < 0.0001f) {
+						baseFov = lastRawFov;
+					}
+				}
+				SCGUIData::sysCamFov = baseFov;
 			}
 			if (g_enable_free_camera) {
 				const auto fov = SCCamera::baseCamera.fov;
 				Unity_set_fieldOfView_hook(_this, fov);
+				return fov;
+			}
+			if (g_enable_camera_offset) {
+				float baseFov = origFov;
+				if (offsetFovValid) {
+					auto diff = origFov - lastAppliedFov;
+					if (diff < 0.0f) diff = -diff;
+					if (diff < 0.0001f) {
+						baseFov = lastRawFov;
+					}
+				}
+				const auto fov = baseFov + SCCamera::baseCamera.fov;
+				Unity_set_fieldOfView_hook(_this, fov);
+
+				offsetFovValid = true;
+				lastRawFov = baseFov;
+				lastAppliedFov = fov;
 				return fov;
 			}
 		}
@@ -2719,18 +2754,47 @@ namespace
 
 	HOOK_ORIG_TYPE Unity_get_position_orig;
 	Vector3_t Unity_get_position_hook(void* _this) {
+		static void* lastTransformForOffset = nullptr;
+		static bool offsetPosValid = false;
+		static Vector3_t lastRawPos{};
+		static Quaternion_t lastRawRot{};
+		static Vector3_t lastAppliedPos{};
+
 		auto data = HOOK_CAST_CALL(Vector3_t, Unity_get_position)(_this);
 		if (_this == baseCameraTransform) {
+			if (lastTransformForOffset != _this) {
+				lastTransformForOffset = _this;
+				offsetPosValid = false;
+			}
+
+			const auto absf = [](float v) { return v < 0.0f ? -v : v; };
+			const bool posAlreadyOffset = offsetPosValid &&
+				(absf(data.x - lastAppliedPos.x) < 0.0001f) &&
+				(absf(data.y - lastAppliedPos.y) < 0.0001f) &&
+				(absf(data.z - lastAppliedPos.z) < 0.0001f);
+
 			auto ret = Unity_get_rotation_hook(_this);
 			if (guiStarting) {
-				SCGUIData::sysCamPos.x = data.x;
-				SCGUIData::sysCamPos.y = data.y;
-				SCGUIData::sysCamPos.z = data.z;
+				if (!g_enable_free_camera && g_enable_camera_offset && posAlreadyOffset) {
+					SCGUIData::sysCamPos.x = lastRawPos.x;
+					SCGUIData::sysCamPos.y = lastRawPos.y;
+					SCGUIData::sysCamPos.z = lastRawPos.z;
 
-				SCGUIData::sysCamRot.w = ret.w;
-				SCGUIData::sysCamRot.x = ret.x;
-				SCGUIData::sysCamRot.y = ret.y;
-				SCGUIData::sysCamRot.z = ret.z;
+					SCGUIData::sysCamRot.w = lastRawRot.w;
+					SCGUIData::sysCamRot.x = lastRawRot.x;
+					SCGUIData::sysCamRot.y = lastRawRot.y;
+					SCGUIData::sysCamRot.z = lastRawRot.z;
+				}
+				else {
+					SCGUIData::sysCamPos.x = data.x;
+					SCGUIData::sysCamPos.y = data.y;
+					SCGUIData::sysCamPos.z = data.z;
+
+					SCGUIData::sysCamRot.w = ret.w;
+					SCGUIData::sysCamRot.x = ret.x;
+					SCGUIData::sysCamRot.y = ret.y;
+					SCGUIData::sysCamRot.z = ret.z;
+				}
 				SCGUIData::updateSysCamLookAt();
 			}
 			if (g_enable_free_camera) {
@@ -2750,6 +2814,41 @@ namespace
 				up->y = 1;
 				up->z = 0;
 				Unity_InternalLookAt_hook(_this, *pos, *up);
+			}
+			else if (g_enable_camera_offset) {
+				Vector3_t basePos = data;
+				Quaternion_t baseRot = ret;
+				if (posAlreadyOffset) {
+					basePos = lastRawPos;
+					baseRot = lastRawRot;
+				}
+
+				Vector3_t baseLookAt{};
+				BaseCamera::CameraPosRotToLookAt(basePos, baseRot, &baseLookAt);
+
+				Vector3_t finalPos{};
+				finalPos.x = basePos.x + SCCamera::baseCamera.pos.x;
+				finalPos.y = basePos.y + SCCamera::baseCamera.pos.y;
+				finalPos.z = basePos.z + SCCamera::baseCamera.pos.z;
+
+				Vector3_t finalLookAt{};
+				finalLookAt.x = baseLookAt.x + SCCamera::baseCamera.lookAt.x;
+				finalLookAt.y = baseLookAt.y + SCCamera::baseCamera.lookAt.y;
+				finalLookAt.z = baseLookAt.z + SCCamera::baseCamera.lookAt.z;
+
+				Unity_set_position_hook(_this, finalPos);
+
+				Vector3_t up{};
+				up.x = 0;
+				up.y = 1;
+				up.z = 0;
+				Unity_InternalLookAt_hook(_this, finalLookAt, up);
+
+				offsetPosValid = true;
+				lastRawPos = basePos;
+				lastRawRot = baseRot;
+				lastAppliedPos = finalPos;
+				data = finalPos;
 			}
 		}
 

--- a/src/hook.cpp
+++ b/src/hook.cpp
@@ -2600,6 +2600,7 @@ namespace
 
 	void* baseCameraTransform = nullptr;
 	void* baseCamera = nullptr;
+	static bool inPositionHook = false;
 
 	HOOK_ORIG_TYPE Unity_set_fieldOfView_orig;
 	void Unity_set_fieldOfView_hook(void* _this, float single) {
@@ -2660,11 +2661,8 @@ namespace
 	HOOK_ORIG_TYPE Unity_InternalLookAt_orig;
 	void Unity_InternalLookAt_hook(void* _this, Vector3_t worldPosition, Vector3_t worldUp) {
 		if (_this == baseCameraTransform) {
-			if (g_enable_free_camera) {
-				auto pos = SCCamera::baseCamera.getLookAt();
-				worldPosition.x = pos.x;
-				worldPosition.y = pos.y;
-				worldPosition.z = pos.z;
+			if (g_enable_free_camera || g_enable_camera_offset) {
+				return;
 			}
 		}
 		return HOOK_CAST_CALL(void, Unity_InternalLookAt)(_this, worldPosition, worldUp);
@@ -2727,25 +2725,21 @@ namespace
 				SCGUIData::sysCamRot.z = ret.z;
 				SCGUIData::updateSysCamLookAt();
 			}
-			if (g_enable_free_camera) {
-				ret.w = 0;
-				ret.x = 0;
-				ret.y = 0;
-				ret.z = 0;
-				Unity_set_rotation_hook(_this, ret);
-
-				static auto Vector3_klass = il2cpp_symbols::get_class("UnityEngine.CoreModule.dll", "UnityEngine", "Vector3");
-				Vector3_t* pos = reinterpret_cast<Vector3_t*>(il2cpp_object_new(Vector3_klass));
-				Vector3_t* up = reinterpret_cast<Vector3_t*>(il2cpp_object_new(Vector3_klass));
-				up->x = 0;
-				up->y = 1;
-				up->z = 0;
-				Unity_InternalLookAt_hook(_this, *pos, *up);
+		if (g_enable_free_camera) {
+				Unity_set_rotation_hook(_this, SCCamera::baseCamera.rot);
+			}
+			else if (g_enable_camera_offset && !inPositionHook) {
+				BaseCamera::CameraCalc::Quaternion baseRotQ(ret.w, ret.x, ret.y, ret.z);
+				BaseCamera::CameraCalc::Quaternion offsetQ(
+					SCCamera::baseCamera.rot.w, SCCamera::baseCamera.rot.x,
+					SCCamera::baseCamera.rot.y, SCCamera::baseCamera.rot.z);
+				auto combinedQ = baseRotQ * offsetQ;
+				Unity_set_rotation_hook(_this, (Quaternion_t)combinedQ);
 			}
 		}
 
-		return ret;
-	}
+	return ret;
+}
 
 	HOOK_ORIG_TYPE Unity_set_position_orig;
 	void Unity_set_position_hook(void* _this, Vector3_t value) {
@@ -2773,9 +2767,11 @@ namespace
 				(absf(data.y - lastAppliedPos.y) < 0.0001f) &&
 				(absf(data.z - lastAppliedPos.z) < 0.0001f);
 
-			auto ret = Unity_get_rotation_hook(_this);
-			if (guiStarting) {
-				if (!g_enable_free_camera && g_enable_camera_offset && posAlreadyOffset) {
+		inPositionHook = true;
+		auto ret = Unity_get_rotation_hook(_this);
+		inPositionHook = false;
+		if (guiStarting) {
+			if (!g_enable_free_camera && g_enable_camera_offset && posAlreadyOffset) {
 					SCGUIData::sysCamPos.x = lastRawPos.x;
 					SCGUIData::sysCamPos.y = lastRawPos.y;
 					SCGUIData::sysCamPos.z = lastRawPos.z;
@@ -2800,20 +2796,6 @@ namespace
 			if (g_enable_free_camera) {
 				SCCamera::baseCamera.updateOtherPos(&data);
 				Unity_set_position_hook(_this, data);
-
-				ret.w = 0;
-				ret.x = 0;
-				ret.y = 0;
-				ret.z = 0;
-				Unity_set_rotation_hook(_this, ret);
-
-				static auto Vector3_klass = il2cpp_symbols::get_class("UnityEngine.CoreModule.dll", "UnityEngine", "Vector3");
-				Vector3_t* pos = reinterpret_cast<Vector3_t*>(il2cpp_object_new(Vector3_klass));
-				Vector3_t* up = reinterpret_cast<Vector3_t*>(il2cpp_object_new(Vector3_klass));
-				up->x = 0;
-				up->y = 1;
-				up->z = 0;
-				Unity_InternalLookAt_hook(_this, *pos, *up);
 			}
 			else if (g_enable_camera_offset) {
 				Vector3_t basePos = data;
@@ -2823,26 +2805,20 @@ namespace
 					baseRot = lastRawRot;
 				}
 
-				Vector3_t baseLookAt{};
-				BaseCamera::CameraPosRotToLookAt(basePos, baseRot, &baseLookAt);
-
 				Vector3_t finalPos{};
 				finalPos.x = basePos.x + SCCamera::baseCamera.pos.x;
 				finalPos.y = basePos.y + SCCamera::baseCamera.pos.y;
 				finalPos.z = basePos.z + SCCamera::baseCamera.pos.z;
 
-				Vector3_t finalLookAt{};
-				finalLookAt.x = baseLookAt.x + SCCamera::baseCamera.lookAt.x;
-				finalLookAt.y = baseLookAt.y + SCCamera::baseCamera.lookAt.y;
-				finalLookAt.z = baseLookAt.z + SCCamera::baseCamera.lookAt.z;
-
 				Unity_set_position_hook(_this, finalPos);
-
-				Vector3_t up{};
-				up.x = 0;
-				up.y = 1;
-				up.z = 0;
-				Unity_InternalLookAt_hook(_this, finalLookAt, up);
+			{
+					BaseCamera::CameraCalc::Quaternion baseRotQ(baseRot.w, baseRot.x, baseRot.y, baseRot.z);
+					BaseCamera::CameraCalc::Quaternion offsetQ(
+						SCCamera::baseCamera.rot.w, SCCamera::baseCamera.rot.x,
+						SCCamera::baseCamera.rot.y, SCCamera::baseCamera.rot.z);
+					auto combinedQ = baseRotQ * offsetQ;
+					Unity_set_rotation_hook(_this, (Quaternion_t)combinedQ);
+				}
 
 				offsetPosValid = true;
 				lastRawPos = basePos;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -234,8 +234,8 @@ namespace
 					if (freeCamConfig.HasMember("enable")) {
 						g_enable_free_camera = freeCamConfig["enable"].GetBool();
 					}
-					if (freeCamConfig.HasMember("enableCameraOffset")) {
-						g_enable_camera_offset = freeCamConfig["enableCameraOffset"].GetBool();
+					if (freeCamConfig.HasMember("enableOffsetCamera")) {
+						g_enable_camera_offset = freeCamConfig["enableOffsetCamera"].GetBool();
 					}
 					if (g_enable_free_camera && g_enable_camera_offset) {
 						g_enable_camera_offset = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,7 @@ char hotKey = 'u';
 float g_font_size_offset = -3.0f;
 
 bool g_enable_free_camera = false;
+bool g_enable_camera_offset = false;
 bool g_block_out_of_focus = false;
 float g_free_camera_mouse_speed = 35;
 bool g_allow_use_tryon_costume = false;
@@ -232,6 +233,12 @@ namespace
 				if (freeCamConfig.IsObject()) {
 					if (freeCamConfig.HasMember("enable")) {
 						g_enable_free_camera = freeCamConfig["enable"].GetBool();
+					}
+					if (freeCamConfig.HasMember("enableCameraOffset")) {
+						g_enable_camera_offset = freeCamConfig["enableCameraOffset"].GetBool();
+					}
+					if (g_enable_free_camera && g_enable_camera_offset) {
+						g_enable_camera_offset = false;
 					}
 					if (freeCamConfig.HasMember("moveStep")) {
 						BaseCamera::moveStep = freeCamConfig["moveStep"].GetFloat() / 1000;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -283,6 +283,8 @@ namespace
 			ReadJsonKeyBinding("key_e_camera_fov_decrease", KEY_E);
 			ReadJsonKeyBinding("key_r_camera_reset", KEY_R);
 			ReadJsonKeyBinding("key_192_camera_mouseMove", KEY_192);
+			ReadJsonKeyBinding("key_numpad7_camera_roll_left", KEY_NUMPAD7);
+			ReadJsonKeyBinding("key_numpad9_camera_roll_right", KEY_NUMPAD9);
 
 			if (document.HasMember("magicacloth_override")) {
 				g_magicacloth_override = document["magicacloth_override"].GetBool();

--- a/src/scgui/scGUILoop.cpp
+++ b/src/scgui/scGUILoop.cpp
@@ -528,7 +528,15 @@ namespace SCGUILoop {
 				ImGui::InputFloat4("Game Camera Rotation (w, x, y, z)", &SCGUIData::sysCamRot.w);
 
 				if (ImGui::CollapsingHeader("Free Camera", ImGuiTreeNodeFlags_DefaultOpen)) {
-					ImGui::Checkbox("Enable Free Camera", &g_enable_free_camera);
+					if (g_enable_free_camera && g_enable_camera_offset) {
+						g_enable_camera_offset = false;
+					}
+					if (ImGui::Checkbox("Enable Free Camera", &g_enable_free_camera) && g_enable_free_camera) {
+						g_enable_camera_offset = false;
+					}
+					if (ImGui::Checkbox("Enable Camera Offset", &g_enable_camera_offset) && g_enable_camera_offset) {
+						g_enable_free_camera = false;
+					}
 					ImGui::Checkbox("Enable ClipPlane overriding", &g_reenable_clipPlane);
 					if (g_reenable_clipPlane) {
 						ImGui::Dummy(ImVec2(40, 0));

--- a/src/scgui/scGUILoop.cpp
+++ b/src/scgui/scGUILoop.cpp
@@ -549,11 +549,11 @@ namespace SCGUILoop {
 						SCCamera::baseCamera.rot.z = SCGUIData::sysCamRot.z;
 						SCCamera::baseCamera.setLookAtFromRot();
 					}
-					if (ImGui::Checkbox("Enable Camera Offset", &g_enable_camera_offset) && g_enable_camera_offset) {
+					if (ImGui::Checkbox("Enable Offset Camera", &g_enable_camera_offset) && g_enable_camera_offset) {
 						g_enable_free_camera = false;
 					}
 					ImGui::SameLine();
-					if (ImGui::Button("Clear Offset")) {
+					if (ImGui::Button("Clear Offsets")) {
 						SCCamera::baseCamera.fov = 0;
 						SCCamera::baseCamera.pos.x = 0;
 						SCCamera::baseCamera.pos.y = 0;

--- a/src/scgui/scGUILoop.cpp
+++ b/src/scgui/scGUILoop.cpp
@@ -521,11 +521,21 @@ namespace SCGUILoop {
 				ImGui::Text("Current 3D Resolution: %d, %d", SCCamera::currRenderResolution.x, SCCamera::currRenderResolution.y);
 			}
 
-			if (ImGui::CollapsingHeader("Camera Info", ImGuiTreeNodeFlags_DefaultOpen)) {
-				ImGui::InputFloat("Game Camera FOV", &SCGUIData::sysCamFov);
-				ImGui::InputFloat3("Game Camera Pos (x, y, z)", &SCGUIData::sysCamPos.x);
-				ImGui::InputFloat3("Game Camera LookAt (x, y, z)", &SCGUIData::sysCamLookAt.x);
-				ImGui::InputFloat4("Game Camera Rotation (w, x, y, z)", &SCGUIData::sysCamRot.w);
+			if (ImGui::CollapsingHeader("Raw Camera Info", ImGuiTreeNodeFlags_DefaultOpen)) {
+				ImGui::BeginDisabled(true);
+				ImGui::InputFloat("Raw FOV", &SCGUIData::sysCamFov);
+				ImGui::InputFloat3("Raw Pos (x, y, z)", &SCGUIData::sysCamPos.x);
+				ImGui::InputFloat3("Raw LookAt (x, y, z)", &SCGUIData::sysCamLookAt.x);
+				ImGui::InputFloat4("Raw Rotation (w, x, y, z)", &SCGUIData::sysCamRot.w);
+				ImGui::EndDisabled();
+				if (ImGui::Button("Apply Raw Camera")) {
+					SCCamera::baseCamera.fov = SCGUIData::sysCamFov;
+					SCCamera::baseCamera.pos.x = SCGUIData::sysCamPos.x;
+					SCCamera::baseCamera.pos.y = SCGUIData::sysCamPos.y;
+					SCCamera::baseCamera.pos.z = SCGUIData::sysCamPos.z;
+					SCCamera::baseCamera.rot = SCGUIData::sysCamRot;
+					SCCamera::baseCamera.setLookAtFromRot();
+				}
 
 				if (ImGui::CollapsingHeader("Free Camera", ImGuiTreeNodeFlags_DefaultOpen)) {
 					if (g_enable_free_camera && g_enable_camera_offset) {
@@ -533,9 +543,25 @@ namespace SCGUILoop {
 					}
 					if (ImGui::Checkbox("Enable Free Camera", &g_enable_free_camera) && g_enable_free_camera) {
 						g_enable_camera_offset = false;
+						SCCamera::baseCamera.rot.w = SCGUIData::sysCamRot.w;
+						SCCamera::baseCamera.rot.x = SCGUIData::sysCamRot.x;
+						SCCamera::baseCamera.rot.y = SCGUIData::sysCamRot.y;
+						SCCamera::baseCamera.rot.z = SCGUIData::sysCamRot.z;
+						SCCamera::baseCamera.setLookAtFromRot();
 					}
 					if (ImGui::Checkbox("Enable Camera Offset", &g_enable_camera_offset) && g_enable_camera_offset) {
 						g_enable_free_camera = false;
+					}
+					ImGui::SameLine();
+					if (ImGui::Button("Clear Offset")) {
+						SCCamera::baseCamera.fov = 0;
+						SCCamera::baseCamera.pos.x = 0;
+						SCCamera::baseCamera.pos.y = 0;
+						SCCamera::baseCamera.pos.z = 0;
+						SCCamera::baseCamera.lookAt.x = 0;
+						SCCamera::baseCamera.lookAt.y = 0;
+						SCCamera::baseCamera.lookAt.z = 0;
+						SCCamera::baseCamera.rot = { 1, 0, 0, 0 };
 					}
 					ImGui::Checkbox("Enable ClipPlane overriding", &g_reenable_clipPlane);
 					if (g_reenable_clipPlane) {
@@ -551,7 +577,16 @@ namespace SCGUILoop {
 					INPUT_AND_SLIDER_FLOAT("Mouse Speed", &g_free_camera_mouse_speed, 0.0f, 100.0f);
 					INPUT_AND_SLIDER_FLOAT("Camera FOV", &SCCamera::baseCamera.fov, 0.0f, 360.0f);
 					ImGui::InputFloat3("Camera Pos (x, y, z)", &SCCamera::baseCamera.pos.x);
+					if (ImGui::IsItemDeactivatedAfterEdit()) {
+						SCCamera::baseCamera.setRotFromLookAt();
+					}
 					ImGui::InputFloat3("Camera LookAt (x, y, z)", &SCCamera::baseCamera.lookAt.x);
+					if (ImGui::IsItemDeactivatedAfterEdit()) {
+						SCCamera::baseCamera.setRotFromLookAt();
+					}
+					if (ImGui::InputFloat4("Camera Rotation (w, x, y, z)", &SCCamera::baseCamera.rot.w)) {
+						SCCamera::baseCamera.setLookAtFromRot();
+					}
 
 					ImGui::Separator();
 					ImGui::Text("Save Camera State:");

--- a/src/stdinclude.hpp
+++ b/src/stdinclude.hpp
@@ -364,6 +364,7 @@ extern std::string g_custom_font_path;
 extern std::filesystem::path g_localify_base;
 extern char hotKey;
 extern bool g_enable_free_camera;
+extern bool g_enable_camera_offset;
 extern bool g_block_out_of_focus;
 extern float g_free_camera_mouse_speed;
 extern bool g_allow_use_tryon_costume;

--- a/src/stdinclude.hpp
+++ b/src/stdinclude.hpp
@@ -45,22 +45,24 @@
 #include "local/local.hpp"
 #include "camera/camera.hpp"
 
-#define KEY_W  87
-#define KEY_S  83
-#define KEY_A  65
-#define KEY_D  68
+#define KEY_W  73
+#define KEY_S  75
+#define KEY_A  74
+#define KEY_D  76
 #define KEY_Q  81
 #define KEY_E  69
 #define KEY_R  82
-#define KEY_UP  38
-#define KEY_DOWN  40
-#define KEY_LEFT  37
-#define KEY_RIGHT  39
+#define KEY_UP  104
+#define KEY_DOWN  98
+#define KEY_LEFT  100
+#define KEY_RIGHT  102
 #define KEY_CTRL  17
 #define KEY_SHIFT  16
 #define KEY_ALT  18
 #define KEY_SPACE  32
 #define KEY_192 192
+#define KEY_NUMPAD7  103
+#define KEY_NUMPAD9  105
 
 #ifdef __SAFETYHOOK
 #include <safetyhook.hpp>


### PR DESCRIPTION
## **What is it for**

The current Free Camera mode is an all-or-nothing override: once enabled, it fully replaces the game camera state with the plugin camera state. That works for manual shots, but it can't preserve the game’s existing camera movement while focusing on a character.

This PR is a proposed feature change of adding a new Offset Camera mode. Instead of fully override the game camera, it takes plugin state as offsets and applies on top of the current in-game camera state. 

It also can be a solution for the discussion #100 .

## **What changed**

### GUI

![000](https://github.com/user-attachments/assets/e745dca2-dbb5-4a4e-8eda-6f4c18dfa5a7)

1. Added a new toggle for Offset mode with a **Clear Offset** button to reset all offset states back to zero.
2. **Offset Camera** and **Free Camera** are mutually exclusive, so only one mode can be enabled at a time.
3. Added direct input controls for **camera rotation** using (w, x, y, z) values.
4. Renamed **Camera Info** to **Raw Camera Info** to make it explicit that this section is read-only and represents the game’s current camera state.
5. Added an **Apply Raw Camera** button to copy the current game camera state into Free Camera.

### Key Bindings

![000](https://github.com/user-attachments/assets/aee06cd5-4043-4307-b40d-412b13ff0a66)

To avoid key overlapping with the game’s native controls, the key bindings were remapped:

- Movement: `W/A/S/D` -> `I/J/K/L`
- Rotation: arrow keys -> numpad `8/4/2/6`
- Added numpad `7/9` for roll control

Numpad-based rotation controls assume NumLock is on.
Also updated the config defaults and readme to accept a new flag `enableOffsetCamera`.

### Hook and SCCamera Logic

Honestly, I am not familiar with math and camera mechanisms, so basically it all fixed by AI. I would not oversell this implementation. What I can confirm is that I tested the in-game behavior and it matches my expectation very well.

Here's AI summary:
_The camera logic was reworked so that camera rotation is handled with **quaternions** instead of the previous angle / look-at driven flow._

_In practice, this brings a few important changes:_

_1. **Offset mode** now applies relative transforms on top of the game camera, instead of replacing it entirely._
_2. **Free Camera** and **Offset Camera** both use the newer rotation path, which behaves more naturally for multi-axis camera control._
_3. The hooks now avoid feeding plugin-written camera values back into themselves, which helps prevent unstable offset accumulation / feedback-loop behavior._
_4. Camera rotation override is handled more directly, instead of relying on zero-rotation + repeated `LookAt` style behavior._

